### PR TITLE
Add waitfor pattern

### DIFF
--- a/src/SerialLibrary/__init__.py
+++ b/src/SerialLibrary/__init__.py
@@ -30,7 +30,7 @@ join = ospath.join
 # unicode type hack
 unicode_ = type('')
 
-    
+
 # add hexlify to codecs
 def hexlify_decode_plus(data, errors='strict'):
     udata, length = hexlify_codec.hex_decode(data, errors)
@@ -524,6 +524,9 @@ class SerialLibrary:
         """
         if size is not None:
             size = float(size)
+        print(terminator, terminator.__class__.__name__)
+        if isinstance(terminator, (bytes, bytearray)):
+            raise TypeError("Terminator type: {}".format(terminator.__class__.__name__))
         if terminator != LF:
             terminator = self._encode(terminator)
         return self._decode(
@@ -759,7 +762,7 @@ class SerialLibrary:
         In former case, path should be absolute or relative to current directory.
         In latter case, file (or file-like object should support read with
         specified length.
-        If offset is non-zero, file is seek()-ed from *current position* 
+        If offset is non-zero, file is seek()-ed from *current position*
         (not the beginning of the file). Note that your the file object should
         support seek() method  with SEEK_CUR.
         If length is negative, all content after current input file position is read.

--- a/src/SerialLibrary/__init__.py
+++ b/src/SerialLibrary/__init__.py
@@ -524,10 +524,7 @@ class SerialLibrary:
         """
         if size is not None:
             size = float(size)
-        print(terminator, terminator.__class__.__name__)
-        if isinstance(terminator, (bytes, bytearray)):
-            raise TypeError("Terminator type: {}".format(terminator.__class__.__name__))
-        if terminator != LF:
+        if terminator != LF and not isinstance(terminator, (bytes, bytearray)):
             terminator = self._encode(terminator)
         return self._decode(
             self._port(port_locator).read_until(terminator=terminator, size=size),

--- a/src/SerialLibrary/__init__.py
+++ b/src/SerialLibrary/__init__.py
@@ -531,7 +531,7 @@ class SerialLibrary:
             self._port(port_locator).read_until(terminator=terminator, size=size),
             encoding)
 
-    def read_until_pattern(self, pattern_regexp, size=None, encoding=None, port_locator=None):
+    def read_until_pattern(self, pattern_regexp, terminator=LF, size=None, encoding=None, port_locator=None):
         """
         Read until a pattern regex definition will be found, size exceeded or timeout.
 
@@ -542,11 +542,10 @@ class SerialLibrary:
         """
         if size is not None:
             size = float(size)
-        terminator = bytes(0)
         if terminator != LF and not isinstance(terminator, (bytes, bytearray)):
             terminator = self._encode(terminator)
         bytes_read = 0
-        regexp = re.compile(pattern_regexp, re.I)
+        regexp = re.compile(pattern_regexp, re.MULTILINE)
         old_timeout = self._port(port_locator).timeout
         start_time = time.time()
         self._port(port_locator).timeout = 0.1
@@ -554,7 +553,7 @@ class SerialLibrary:
         while True:
             if (size is not None):
                 size = size - bytes_read
-                if not size:
+                if size < 0.01:
                     break
             new_data = self._decode(
                 self._port(port_locator).read_until(terminator=terminator, size=size),
@@ -563,7 +562,9 @@ class SerialLibrary:
                 start_time = time.time()
             buffer += new_data
             bytes_read = len(new_data)
-            if regexp.match(buffer) or ((time.time() - start_time()) > old_timeout):
+
+            regexp_search = regexp.search(buffer)
+            if regexp_search or (time.time() - start_time > old_timeout):
                 break
         self._port(port_locator).timeout = old_timeout
         return buffer

--- a/src/SerialLibrary/__init__.py
+++ b/src/SerialLibrary/__init__.py
@@ -531,9 +531,9 @@ class SerialLibrary:
             self._port(port_locator).read_until(terminator=terminator, size=size),
             encoding)
 
-    def read_until_pattern(self, pattern_regexp, terminator=LF, size=None, encoding=None, port_locator=None):
+    def read_until_pattern(self, pattern, terminator=LF, size=None, encoding=None, port_locator=None):
         """
-        Read until a pattern regex definition is found, size exceeded or timeout.
+        Read until a (multiline) pattern is found, size exceeded or timeout.
 
         If `encoding` is not given, default encoding is used.
         Note that encoding affects terminator too, so if you want to use
@@ -545,7 +545,7 @@ class SerialLibrary:
         if terminator != LF and not isinstance(terminator, (bytes, bytearray)):
             terminator = self._encode(terminator)
         port = self._port(port_locator)
-        regexp = re.compile(pattern_regexp, re.MULTILINE)
+        regexp = re.compile(pattern, re.MULTILINE)
         old_timeout = port.timeout
         port.timeout = 0.1
         start_time = time.time()


### PR DESCRIPTION
Provides the new feature to wait for some regexp pattern from UART instead of just terminator-string. For instance, GSM-modems can return values ".*(OK|ERROR)" regexp
